### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# aws-lb-readvertiser maintainers
+*   @rfranzke

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,0 @@
-Maintainers of this repository:
-
-* Rafael Franzke <rafael.franzke@sap.com> @rfranzke


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/