### PR TITLE
Fix empty endpoint subset panic

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -20,7 +20,7 @@ func checkEndpointIsStillValid(currentEndpointValues []string, elbFetchedRecords
 }
 
 // createEndpointSubset creates an endpoint subset from a set of IPs and currently with a constant port 443
-func createEndpointSubsetFromRecords(ips []string) (*corev1.EndpointSubset, error) {
+func createEndpointSubsetObjectFromRecords(ips []string) (*corev1.EndpointSubset, error) {
 	if len(ips) == 0 {
 		return nil, errors.New("Empty list of IPs")
 	}


### PR DESCRIPTION
In some cases, the endpoint might exists without any content, as a
result the endpoint subset will be uninitialized and will cause panics.

This commit fixes this issue by considering this case as well.

```improvement operator
An issue causing the aws-lb-readvertiser to panic in case the `.subsets` field of the `Endpoint` object is empty has been fixed.
```