### PR TITLE
Ensure that requests from re-advertiser are fully qualified

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -54,6 +55,11 @@ func (a *AWSReadvertiserOptions) addFlags() {
 func (a *AWSReadvertiserOptions) validateFlags() error {
 	if len(a.elb) == 0 {
 		return fmt.Errorf("The DNS value for the ELB needs to be set properly")
+	}
+
+	// Check to see if the domain is a valid FQDN
+	if !strings.HasSuffix(a.elb, ".") {
+		a.elb = fmt.Sprintf("%s.", a.elb)
 	}
 
 	if a.refreshPeriod == 0 {


### PR DESCRIPTION
Ensure that requests from re-advertiser are fully qualified, this way the load on CoreDNS is reduced as the requests would go directly to the external nameserver without iterating over the search path.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The `aws-lb-readvertiser` does now ensure that the load balancer name provided via command line flags is a FQDN. If not, it will automatically convert it before starting the control loops.
```