### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.15.4
-
-RUN apk add --update bash curl
+FROM gcr.io/distroless/static-debian11:nonroot
 
 ADD ./bin/rel/aws-lb-readvertiser /aws-lb-readvertiser
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for `aws-lb-readvertiser` from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `aws-lb-readvertiser` now uses `distroless` instead of `alpine` as a base image.
```
