### PR TITLE
Update golang version

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,9 +23,9 @@ aws-lb-readvertiser:
             image: 'eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser'
     steps:
       check:
-        image: 'golang:1.18.1'
+        image: 'golang:1.18.5'
       build:
-        image: 'golang:1.18.1'
+        image: 'golang:1.18.5'
         output_dir: 'binary'
   jobs:
     head-update:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang version to get rid of [CVE-2022-30634](https://nvd.nist.gov/vuln/detail/CVE-2022-30634)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
