### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,6 +9,9 @@ aws-lb-readvertiser:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        component_name: 'github.com/gardener/aws-lb-readvertiser'
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
           aws-lb-readvertiser:
@@ -17,7 +20,7 @@ aws-lb-readvertiser:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/aws-lb-readvertiser
     steps:
       check:
         image: 'golang:1.19.4'
@@ -28,7 +31,9 @@ aws-lb-readvertiser:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -36,7 +41,11 @@ aws-lb-readvertiser:
       traits:
         version:
           preprocess: 'finalize'
+        publish:
+          dockerimages:
+            aws-lb-readvertiser:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/aws-lb-readvertiser
         release:
           nextversion: 'bump_minor'
         component_descriptor:
-          component_name: 'github.com/gardener/aws-lb-readvertiser'
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,9 +23,9 @@ aws-lb-readvertiser:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/aws-lb-readvertiser
     steps:
       check:
-        image: 'golang:1.19.4'
+        image: 'golang:1.20.12'
       build:
-        image: 'golang:1.19.4'
+        image: 'golang:1.20.12'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 aws-lb-readvertiser:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -19,7 +17,6 @@ aws-lb-readvertiser:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser'
     steps:
       check:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-IMAGE_REPOSITORY              := eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser
+IMAGE_REPOSITORY              := europe-docker.pkg.dev/gardener-project/public/gardener/aws-lb-readvertiser
 IMAGE_TAG                     := $(shell cat VERSION)
 GOLANGCI_LINT_CONFIG_FILE     := "./.golangci.yaml"
 REPO_ROOT                     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ REPO_ROOT                     := $(shell dirname $(realpath $(lastword $(MAKEFIL
 .PHONY: install-requirements
 install-requirements:
 	# install golangci-lint
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
 .PHONY: revendor
 revendor:

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         operator: Exists
       containers:
       - name: aws-lb-readvertiser
-        image: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser:0.4.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/aws-lb-readvertiser:0.4.0
         imagePullPolicy: IfNotPresent
         args:
         - --kubeconfig=/var/lib/aws-lb-readvertiser/kubeconfig


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
